### PR TITLE
Added method to find the number of expanded children before the item

### DIFF
--- a/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
+++ b/expandablerecyclerview/src/main/java/com/bignerdranch/expandablerecyclerview/Adapter/ExpandableRecyclerAdapter.java
@@ -3,7 +3,6 @@ package com.bignerdranch.expandablerecyclerview.Adapter;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.ViewGroup;
 
 import com.bignerdranch.expandablerecyclerview.ClickListeners.ExpandCollapseListener;
@@ -319,11 +318,12 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
         }
         if (parentWrapper.isExpanded()) {
             parentWrapper.setExpanded(false);
-            
+
             if (mExpandCollapseListener != null) {
-                mExpandCollapseListener.onRecyclerViewItemCollapsed(position);
+                int expandedCountBeforePosition = getExpandedItemCount(position);
+                mExpandCollapseListener.onRecyclerViewItemCollapsed(position - expandedCountBeforePosition);
             }
-            
+
             mStableIdMap.put(parentWrapper.getStableId(), false);
             List<Object> childObjectList = ((ParentObject) parentWrapper.getParentObject()).getChildObjectList();
             if (childObjectList != null) {
@@ -331,16 +331,16 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                     mItemList.remove(position + i + 1);
                     mExpandableRecyclerAdapterHelper.getHelperItemList().remove(position + i + 1);
                     notifyItemRemoved(position + i + 1);
-                    Log.d(TAG, "Removed " + childObjectList.get(i).toString());
                 }
             }
         } else {
             parentWrapper.setExpanded(true);
-            
+
             if (mExpandCollapseListener != null) {
-                mExpandCollapseListener.onRecyclerViewItemExpanded(position);
+                int expandedCountBeforePosition = getExpandedItemCount(position);
+                mExpandCollapseListener.onRecyclerViewItemExpanded(position - expandedCountBeforePosition);
             }
-            
+
             mStableIdMap.put(parentWrapper.getStableId(), true);
             List<Object> childObjectList = ((ParentObject) parentWrapper.getParentObject()).getChildObjectList();
             if (childObjectList != null) {
@@ -351,6 +351,27 @@ public abstract class ExpandableRecyclerAdapter<PVH extends ParentViewHolder, CV
                 }
             }
         }
+    }
+
+    /**
+     * Method to get the number of expanded children before the specified position.
+     *
+     * @param position
+     * @return number of expanded children before the specified position
+     */
+    private int getExpandedItemCount(int position) {
+        if (position == 0) {
+            return 0;
+        }
+
+        int expandedCount = 0;
+        for (int i = 0; i < position; i++) {
+            Object object = mItemList.get(i);
+            if (!(object instanceof ParentObject)) {
+                expandedCount++;
+            }
+        }
+        return expandedCount;
     }
 
     /**


### PR DESCRIPTION
I went ahead and wrote a method to do this as we mentioned on Reddit. It now returns the correct position. Go ahead and check this out and merge it in with your fork if you think it is good. Then we can merge it with the BNR repo pending code review from one other person.